### PR TITLE
added set env to always be run when running sitecore-switch-to-solr a…

### DIFF
--- a/gulp-tasks/sitecore-switch-to-solr.js
+++ b/gulp-tasks/sitecore-switch-to-solr.js
@@ -8,6 +8,14 @@ var powershell = require("../modules/powershell");
 var path = require("path");
 var fs = require("fs")
 
+var nopt = require("nopt");
+
+var args = nopt({
+  "env"     : [String, null]
+});
+
+build.setEnvironment(args.env);
+
 gulp.task("sitecore-switch-to-solr", function (callback) { 
   // Can be done with gulp-run? https://www.npmjs.com/package/gulp-run
   var taskDir = path.dirname(fs.realpathSync(__filename));


### PR DESCRIPTION
setEnvironment wasnt being run when running sitecore-switch-to-solr by it self. This has been fixed.

Could probably be done nicer. 
